### PR TITLE
Creation of dynamic property is deprecated. Fixed variable name.

### DIFF
--- a/Edirect/Erli/Helper/Data.php
+++ b/Edirect/Erli/Helper/Data.php
@@ -170,7 +170,7 @@ class Data extends AbstractHelper
         $this->getSalableQuantityDataBySku = $getSalableQuantityDataBySku;
         $this->resourceProductTypeConfigurable = $resourceProductTypeConfigurable;
         $this->priceRule = $priceRule;
-        $this->_helperOutput = $helperOutput;
+        $this->helperOutput = $helperOutput;
     }
 
     /**
@@ -373,7 +373,7 @@ class Data extends AbstractHelper
         $result1 = [
             'product_id' => $product->getId(),
             'name' => $product->getName(),
-            'description' =>  $this->_helperOutput->productAttribute(
+            'description' =>  $this->helperOutput->productAttribute(
                 $product,
                 $product->getDescription(),
                 'description'
@@ -412,7 +412,7 @@ class Data extends AbstractHelper
                 $parentId = $this->getParentId($product->getId());
                 $parent = $this->productRepository->getById($parentId);
                 //$parentDescription = $parent->getDescription();
-                $parentDescription = $this->_helperOutput->productAttribute(
+                $parentDescription = $this->helperOutput->productAttribute(
                     $parent,
                     $parent->getDescription(),
                     'description'

--- a/Edirect/Erli/Model/System/Message/ErliNotification.php
+++ b/Edirect/Erli/Model/System/Message/ErliNotification.php
@@ -28,7 +28,7 @@ class ErliNotification implements MessageInterface
     /**
      * @var UrlInterface
      */
-    protected $urlBuider;
+    protected $urlBuilder;
 
     /**
      * @var ResourceConnection


### PR DESCRIPTION
magento 2.4.6-p4 & PHP 8.3
bin/magento setup:di:compile throws:
"Deprecated Functionality: Creation of dynamic property Edirect\Erli\Helper\Data::$_helperOutput is deprecated in /var/www/html/app/code/Edirect/Erli/Helper/Data.php on line 173"

